### PR TITLE
getPlugin() was failing, fixed by adding extension name as one parame…

### DIFF
--- a/docs/api/plugins/system.md
+++ b/docs/api/plugins/system.md
@@ -4,7 +4,7 @@ title: Plugins System API
 sidebar_label: System
 ---
 
-The System API is the most basic API which Selenium IDE provides. It is not prefixed and can be called with `/`. 
+The System API is the most basic API which Selenium IDE provides. It is not prefixed and can be called with `/`.
 
 #### Opening Selenium IDE
 If the extension is installed, a request could be made by a plugin to open Selenium IDE.
@@ -59,7 +59,7 @@ Loads a project into the IDE, as if the user opened it, if the user has unsaved 
 
 ```js
 {
+  name: "your extension name"
   project: JSON parsed side file
 }
 ```
-

--- a/packages/selenium-ide/src/api/v1/index.js
+++ b/packages/selenium-ide/src/api/v1/index.js
@@ -63,13 +63,12 @@ router.get('/project', (_req, res) => {
 })
 
 router.post('/project', (req, res) => {
-  if (req.id) {
-    const plugin = Manager.getPlugin(req.sender)
+  if (req.project) {
     if (!UiState.isSaved()) {
       ModalState.showAlert({
         title: 'Open project without saving',
         description: `${
-          plugin.name
+          req.name
         } is trying to load a project, are you sure you want to load this project and lose all unsaved changes?`,
         confirmLabel: 'proceed',
         cancelLabel: 'cancel',
@@ -81,18 +80,8 @@ router.post('/project', (req, res) => {
       })
       res(true)
     } else {
-      ModalState.hideWelcome()
-      ModalState.showAlert({
-        title: 'Open project',
-        description: `${plugin.name} is trying to load a project`,
-        confirmLabel: 'proceed',
-        cancelLabel: 'cancel',
-      }).then(result => {
-        if (result) {
-          loadJSProject(UiState.project, req.project)
-          ModalState.completeWelcome()
-        }
-      })
+      loadJSProject(UiState.project, req.project)
+      ModalState.completeWelcome()
       res(true)
     }
   }


### PR DESCRIPTION
…ter in the payload's api call

<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
